### PR TITLE
Changed config.ini location to AppDomain base directory

### DIFF
--- a/vsgallery/Program.cs
+++ b/vsgallery/Program.cs
@@ -1,4 +1,6 @@
-﻿using Topshelf;
+﻿using System;
+using System.IO;
+using Topshelf;
 using vsgallery.Webserver;
 
 namespace vsgallery
@@ -10,7 +12,7 @@ namespace vsgallery
             // Ensure global single instance
 
             // Load the ini configuration file
-            IConfiguration config = new Configuration("config.ini");
+            IConfiguration config = new Configuration(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "config.ini"));
 
             HostFactory.Run(x =>
             {


### PR DESCRIPTION
I couldn't start the application when it was installed as a service.
Turns out it tries to find the config.ini from a different location.
Vsgallery now tries to find it in the application location.