### PR TITLE
Workaround for empty entry when no match is found between entryName and entries in VSIX

### DIFF
--- a/vsgallery/Vsix/VsixPackage.cs
+++ b/vsgallery/Vsix/VsixPackage.cs
@@ -72,6 +72,12 @@ namespace vsgallery.Vsix
             using (var zip = ZipFile.OpenRead(File))
             {
                 var entry = zip.GetEntry(entryName);
+                // Entry could be null because spaces in filenames in a VSIX are encoded to '%20', so retry with encoded entryName
+                if (entry == null)
+                {
+                    entryName = Uri.EscapeDataString(entryName);
+                    entry = zip.GetEntry(entryName);
+                }
                 if (entry != null)
                 {
                     var itemPath = Path.Combine(destinationFolder, entryName);


### PR DESCRIPTION
After setting up vsgallery, my feed didn't show icons.
After doing some research I found out that when trying to get the icon from the VSIX, no match could be found between the icon name in the manifest and the filename in the VSIX.
Turns out that spaces in filenames of files inside a VSIX are encoded to '%20', and spaces in the filename in the manifest are not.

So I added a check after trying to get the entry from the VSIX , that checks if an entry is found.
If an entry is found the code continues normally.
If no entry is found vsgallery will try again with an encoded filename.
