### PR TITLE
Fix Blanks and Subfolder issue

### DIFF
--- a/vsgallery/Vsix/VsixPackage.cs
+++ b/vsgallery/Vsix/VsixPackage.cs
@@ -75,7 +75,7 @@ namespace vsgallery.Vsix
                 // Entry could be null because spaces in filenames in a VSIX are encoded to '%20', so retry with encoded entryName
                 if (entry == null)
                 {
-                    entryName = Uri.EscapeDataString(entryName);
+                    entryName = Uri.EscapeUriString(entryName);
                     entry = zip.GetEntry(entryName);
                 }
                 if (entry != null)


### PR DESCRIPTION
Fix special handling with subfolders and blanks, if entryName to be extracted is in a subfolder EscapeData will escape directory delimitter as well, where EscapeUri will leave directory delimitter untouched
https://blogs.msdn.microsoft.com/yangxind/2006/11/08/dont-use-net-system-uri-unescapedatastring-in-url-decoding/