### PR TITLE
Minor Cleanups: remove unused parameter from method signature

### DIFF
--- a/vsgallery/FileHelpers/FileCounter.cs
+++ b/vsgallery/FileHelpers/FileCounter.cs
@@ -11,13 +11,13 @@ namespace vsgallery.FileHelpers
         private static readonly ReaderWriterLockSlim ratingsFileLock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
 
 
-        public static bool SetIdToVsixFile(string vsixId, string vsixFile, IConfiguration configuration)
+        public static bool SetIdToVsixFile(string vsixId, string vsixFile, IStorageConfiguration configuration)
         {
             vsixInfoFileLock.EnterWriteLock();
             // Attempt to find the file, if exists then read the only file in it into memory
             try
             {
-                string vsixMarkPath = Path.Combine(Environment.CurrentDirectory, configuration.Storage.VsixStorageDirectory, "VSIXData", vsixId, "info.txt");
+                string vsixMarkPath = Path.Combine(Environment.CurrentDirectory, configuration.VsixStorageDirectory, "VSIXData", vsixId, "info.txt");
 
                 // Increment download count and write to the file again
                 File.WriteAllText(vsixMarkPath, vsixFile);
@@ -37,18 +37,18 @@ namespace vsgallery.FileHelpers
             }
         }
 
-        public static string GetVsixFileFromId(string vsixId, IConfiguration configuration)
+        public static string GetVsixFileFromId(string vsixId, IStorageConfiguration configuration)
         {
             vsixInfoFileLock.EnterReadLock();
             try
             {
-                string vsixMarkPath = Path.Combine(Environment.CurrentDirectory, configuration.Storage.VsixStorageDirectory, "VSIXData", vsixId, "info.txt");
+                string vsixMarkPath = Path.Combine(Environment.CurrentDirectory, configuration.VsixStorageDirectory, "VSIXData", vsixId, "info.txt");
 
                 if (!File.Exists(vsixMarkPath))
                     return null;
 
                 var fileName = File.ReadAllText(vsixMarkPath);
-                return Path.Combine(Environment.CurrentDirectory, configuration.Storage.VsixStorageDirectory, fileName);
+                return Path.Combine(Environment.CurrentDirectory, configuration.VsixStorageDirectory, fileName);
             }
             catch (Exception e)
             {
@@ -61,15 +61,15 @@ namespace vsgallery.FileHelpers
             }
         }
 
-        public static bool SetDownloadCount(string vsixId, string vsixFile, IConfiguration configuration)
+        public static bool SetDownloadCount(string vsixId, IStorageConfiguration configuration)
         {
             downloadCountFileLock.EnterWriteLock();
             // Attempt to find the file, if exists then read the only file in it into memory
             try
             {
-                string vsixDownloadCountPath = Path.Combine(Environment.CurrentDirectory, configuration.Storage.VsixStorageDirectory, "VSIXData", vsixId, "downloads.txt");
+                string vsixDownloadCountPath = Path.Combine(Environment.CurrentDirectory, configuration.VsixStorageDirectory, "VSIXData", vsixId, "downloads.txt");
 
-                int downloadCount = CoreGetDownloadCount(vsixId, vsixFile, configuration);
+                int downloadCount = CoreGetDownloadCount(vsixId, configuration);
 
                 // Increment download count and write to the file again
                 File.WriteAllText(vsixDownloadCountPath, (++downloadCount).ToString());
@@ -89,12 +89,12 @@ namespace vsgallery.FileHelpers
             }
         }
 
-        public static int GetDownloadCount(string vsixId, string vsixFile, IConfiguration configuration)
+        public static int GetDownloadCount(string vsixId, IStorageConfiguration configuration)
         {
             downloadCountFileLock.EnterReadLock();
             try
             {
-                return CoreGetDownloadCount(vsixId, vsixFile, configuration);
+                return CoreGetDownloadCount(vsixId, configuration);
             }
             finally
             {
@@ -102,10 +102,10 @@ namespace vsgallery.FileHelpers
             }
         }
 
-        private static int CoreGetDownloadCount(string vsixId, string vsixFile, IConfiguration configuration)
+        private static int CoreGetDownloadCount(string vsixId, IStorageConfiguration configuration)
         {
             try { 
-                string vsixDownloadCountPath = Path.Combine(Environment.CurrentDirectory, configuration.Storage.VsixStorageDirectory, "VSIXData", vsixId, "downloads.txt");
+                string vsixDownloadCountPath = Path.Combine(Environment.CurrentDirectory, configuration.VsixStorageDirectory, "VSIXData", vsixId, "downloads.txt");
 
                 int downloadCount = 0;
                 if (File.Exists(vsixDownloadCountPath))
@@ -123,12 +123,12 @@ namespace vsgallery.FileHelpers
             
         }
 
-        public static bool SetRating(string vsixId, float rating, IConfiguration configuration)
+        public static bool SetRating(string vsixId, float rating, IStorageConfiguration configuration)
         {
             ratingsFileLock.EnterWriteLock();
             try
             {
-                string vsixDownloadRatingPath = Path.Combine(Environment.CurrentDirectory, configuration.Storage.VsixStorageDirectory, "VSIXData", vsixId, "ratings.txt");
+                string vsixDownloadRatingPath = Path.Combine(Environment.CurrentDirectory, configuration.VsixStorageDirectory, "VSIXData", vsixId, "ratings.txt");
 
                 var ratingAndCount = CoreGetRating(vsixId, configuration);
 
@@ -155,7 +155,7 @@ namespace vsgallery.FileHelpers
             }
         }
 
-        public static Tuple<float, int> GetRating(string vsixId, IConfiguration configuration)
+        public static Tuple<float, int> GetRating(string vsixId, IStorageConfiguration configuration)
         {
             ratingsFileLock.EnterReadLock();
             try
@@ -168,11 +168,11 @@ namespace vsgallery.FileHelpers
             }
         }
 
-        private static Tuple<float, int> CoreGetRating(string vsixId, IConfiguration configuration)
+        private static Tuple<float, int> CoreGetRating(string vsixId, IStorageConfiguration configuration)
         {
             try
             {
-                string vsixDownloadRatingPath = Path.Combine(Environment.CurrentDirectory, configuration.Storage.VsixStorageDirectory, "VSIXData", vsixId, "ratings.txt");
+                string vsixDownloadRatingPath = Path.Combine(Environment.CurrentDirectory, configuration.VsixStorageDirectory, "VSIXData", vsixId, "ratings.txt");
                 if (File.Exists(vsixDownloadRatingPath))
                 {
                     // Attempt to read the download count, don't care if it fails really...

--- a/vsgallery/VsixFeed/VsixStorageWatcher.cs
+++ b/vsgallery/VsixFeed/VsixStorageWatcher.cs
@@ -15,10 +15,10 @@ namespace vsgallery.VsixFeed
         private readonly object _lock = new object();
         private bool _isRunning = false;
 
-        public VsixStorageWatcher(string vsixDirectory, IConfiguration config)
+        public VsixStorageWatcher(string vsixDirectory, IStorageConfiguration storageConfig, IGalleryConfiguration galleryConfig)
         {
             _vsixDirectory = vsixDirectory;
-            _feedBuilder = new VsixFeedBuilder(config);
+            _feedBuilder = new VsixFeedBuilder(storageConfig, galleryConfig);
             _feedBuilder.BackgroundProgress += FeedBuilderOnBackgroundProgress;
         }
 
@@ -29,10 +29,12 @@ namespace vsgallery.VsixFeed
 
         public void Start()
         {
-            _fsWatcher = new FileSystemWatcher();
-            _fsWatcher.Path = _vsixDirectory;
-            _fsWatcher.NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite;
-            _fsWatcher.Filter = "*.vsix";
+            _fsWatcher = new FileSystemWatcher
+            {
+                Path = _vsixDirectory,
+                NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite,
+                Filter = "*.vsix"
+            };
             _fsWatcher.Created += OnDirectoryChanged;
             _fsWatcher.Deleted += OnDirectoryChanged;
             _fsWatcher.Changed += OnDirectoryChanged;

--- a/vsgallery/Webserver/ApiModules/DownloadModule.cs
+++ b/vsgallery/Webserver/ApiModules/DownloadModule.cs
@@ -9,8 +9,8 @@ namespace vsgallery.Webserver.ApiModules
 {
     public class DownloadModule: NancyModule
     {
-        private readonly IConfiguration _configuration;
-        public DownloadModule(IConfiguration configuration)
+        private readonly IStorageConfiguration _configuration;
+        public DownloadModule(IStorageConfiguration configuration)
         {
             _configuration = configuration;
 
@@ -22,10 +22,10 @@ namespace vsgallery.Webserver.ApiModules
         {
             string vsixName = HttpUtility.UrlDecode(parameters.vsix);
             string vsixId = parameters.id;
-            string vsixFilePath = Path.Combine(Environment.CurrentDirectory, _configuration.Storage.VsixStorageDirectory, vsixName);
+            string vsixFilePath = Path.Combine(Environment.CurrentDirectory, _configuration.VsixStorageDirectory, vsixName);
 
             // Count the download
-            bool refreshFile = FileCounter.SetDownloadCount(vsixId, vsixName, _configuration);
+            bool refreshFile = FileCounter.SetDownloadCount(vsixId, _configuration);
 
             // Serve the requested VSIX file back to the caller
             Response fileResponse = null;

--- a/vsgallery/Webserver/ApiModules/RatingsModule.cs
+++ b/vsgallery/Webserver/ApiModules/RatingsModule.cs
@@ -8,9 +8,9 @@ namespace vsgallery.Webserver.ApiModules
 {
     public class RatingsModule : NancyModule
     {
-        private readonly IConfiguration _configuration;
+        private readonly IStorageConfiguration _configuration;
 
-        public RatingsModule(IConfiguration configuration)
+        public RatingsModule(IStorageConfiguration configuration)
         {
             _configuration = configuration;
 

--- a/vsgallery/Webserver/SelfHost.cs
+++ b/vsgallery/Webserver/SelfHost.cs
@@ -33,7 +33,7 @@ namespace vsgallery.Webserver
 
             // Create the VSIX feed
             _vsixStoragePath = Path.Combine(Environment.CurrentDirectory, _config.Storage.VsixStorageDirectory);
-            _vsixStorageWatcher = new VsixStorageWatcher(_vsixStoragePath, _config);
+            _vsixStorageWatcher = new VsixStorageWatcher(_vsixStoragePath, _config.Storage, _config.Gallery);
             _vsixStorageWatcher.Start();
             _nancyHost.Start();
         }


### PR DESCRIPTION
 started with some minor cleanups, 

- remove unused parameter from method signature
- reduce IConfiguration usage to the needed minimum